### PR TITLE
#8: Refactored Datafolder path generation  + tests

### DIFF
--- a/app_main.py
+++ b/app_main.py
@@ -2,10 +2,16 @@
 Main script, menu.
 """
 import os
-# import pathlib
+from enum import Enum
 import sys
 
 from dionysus_app.main_menu import run_main_menu
+
+
+class DataFolder(Enum):
+    APP_DATA = './dionysus_app/app_data'
+    CLASS_DATA = './dionysus_app/app_data/class_data'
+    IMAGE_DATA = './dionysus_app/app_data/image_data'
 
 
 def data_folder_check():
@@ -16,13 +22,20 @@ def data_folder_check():
     """
 
     data_folders = {
-        'relpath_app_data': r'./dionysus_app/app_data',  # TODO: check these paths work on Windows
-        'relpath_class_data': r'./dionysus_app/app_data/class_data',
-        'relpath_image_data': r'./dionysus_app/app_data/image_data',
+        DataFolder.APP_DATA: generate_rel_path(DataFolder.APP_DATA.value),
+        DataFolder.CLASS_DATA: generate_rel_path(DataFolder.CLASS_DATA.value),
+        DataFolder.IMAGE_DATA: generate_rel_path(DataFolder.IMAGE_DATA.value),
     }
     for key in data_folders:
         if not os.path.exists(data_folders[key]):
             os.makedirs(data_folders[key])
+
+
+def generate_rel_path(path):
+    if not path:
+        return os.getcwd()
+    path = path.split('/')
+    return os.path.abspath(os.path.join(os.getcwd(), *path))
 
 
 def run_app():

--- a/test_suite/test_app_main.py
+++ b/test_suite/test_app_main.py
@@ -1,0 +1,37 @@
+import unittest
+import os
+from app_main import generate_rel_path, data_folder_check
+
+
+class TestAppMain(unittest.TestCase):
+
+    def setUp(self):
+        self.default_paths = [
+            r'/dionysus_app/app_data',
+            r'/dionysus_app/app_data/class_data',
+            r'dionysus_app/app_data/image_data'
+        ]
+
+    def test_generate_data_path_defaults(self):
+
+        os.chdir(os.path.join(os.getcwd(), '..'))
+        for path in self.default_paths:
+
+            path_result = generate_rel_path(path)
+            assert path in path_result and os.getcwd() in path_result
+
+    def test_generate_data_path_None(self):
+        path_result = generate_rel_path(None)
+        assert os.getcwd() in path_result
+
+
+    def test_data_folder_check_default(self):
+        default_paths = [
+            r'/dionysus_app/app_data',
+            r'/dionysus_app/app_data/class_data',
+            r'dionysus_app/app_data/image_data'
+        ]
+        data_folder_check()
+        for path in default_paths:
+            data_folder_path = generate_rel_path(path)
+            assert os.path.exists(data_folder_path)


### PR DESCRIPTION
Refactored Datafolder path generation for both windows and linux support, also added some tests around a new helper function and data folder check. 

To run tests:

`pytest` in root directory