### PR TITLE
Require successful Python 3.7 build on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ python:
 
 
 matrix:
-    include:  # workaround for python 3.7 
+    include:  # Workaround for python 3.7.
         - python: "3.7"
           dist: xenial
-          sudo: required 
-      
+          sudo: required
+         vvv 
     fast_finish: true
     allow_failures:
         - os: windows  # allow failure on Win until Travis-Win supports python.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ cache: pip
 
 python:
     - "3.6"
-
+    -  "3.7"
 
 
 matrix:
     include:  # workaround for python 3.7 
-        - python: 3.7
+        - python: "3.7"
           dist: xenial
           sudo: required
       

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,20 @@ os:
 cache: pip
 
 python:
-    - 3.6
-   - "3.7"
+    - "3.6"
+    - "3.7"
 
 
 matrix:
     include:  # workaround for python 3.7 
-        - python: 3.7
+        - python: "3.7"
           dist: xenial
           sudo: required 
       
     fast_finish: true
     allow_failures:
         - os: windows  # allow failure on Win until Travis-Win supports python.
-        - python: 3.7  # Travis CI not supporting 3.7 yet
+        - python: "3.7"  # Travis CI not supporting 3.7 yet
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,14 @@ cache: pip
 
 python:
     - "3.6"
-    - "3.7"
 
 
 
 matrix:
     include:  # workaround for python 3.7 
-    - python: 3.7
-      dist: xenial
-      sudo: true
+        - python: 3.7
+          dist: xenial
+          sudo: true
       
     fast_finish: true
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     fast_finish: true
     allow_failures:
         - os: windows  # allow failure on Win until Travis-Win supports python.
-        - python: "3.7"  # Travis CI not supporting 3.7 yet
+#        - python: "3.7"  # Travis CI not supporting 3.7 yet
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-
+sudo: false
 os:
   - windows
   - linux
@@ -8,20 +8,20 @@ os:
 cache: pip
 
 python:
-    - "3.6"
+    - 3.6
 #    - "3.7"
 
 
 matrix:
     include:  # workaround for python 3.7 
-        - python: "3.7"
+        - python: 3.7
           dist: xenial
-          sudo: true
+          sudo: required 
       
     fast_finish: true
     allow_failures:
         - os: windows  # allow failure on Win until Travis-Win supports python.
-        - python: "3.7"  # Travis CI not supporting 3.7 yet
+        - python: 3.7  # Travis CI not supporting 3.7 yet
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     include:  # workaround for python 3.7 
         - python: 3.7
           dist: xenial
-          sudo: true
+          sudo: required
       
     fast_finish: true
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ python:
     - "3.7"
 
 
+
 matrix:
+    include:  # workaround for python 3.7 
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      
     fast_finish: true
     allow_failures:
         - os: windows  # allow failure on Win until Travis-Win supports python.
@@ -23,7 +29,7 @@ install:
     - pip install -r requirements_dev.txt
     - pip install -r requirements.txt
 
-    - pip install pytest-cov
+    - pip install pytest-cov  # TODO: Move test dependencies to requirements_dev
     - pip install coveralls
     - pip install coverage
     - pip install codacy-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - python: "3.7"
           dist: xenial
           sudo: required
-         vvv 
+
     fast_finish: true
     allow_failures:
         - os: windows  # allow failure on Win until Travis-Win supports python.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ cache: pip
 
 python:
     - "3.6"
-    -  "3.7"
+#    - "3.7"
 
 
 matrix:
     include:  # workaround for python 3.7 
         - python: "3.7"
           dist: xenial
-          sudo: required
+          sudo: true
       
     fast_finish: true
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 sudo: false
+dist: xenial
+
 os:
   - windows
   - linux
@@ -9,7 +11,7 @@ cache: pip
 
 python:
     - 3.6
-#    - "3.7"
+   - "3.7"
 
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CI/Testing
+    - Travis CI
+        - Use Python 3.7 Xenial distribution for Travis to build.
+        - Require passing tests Python 3.7 on Linux for successful build.
+
 
 ## [0.1.1-alpha] - 2018-12-12
 ### Added


### PR DESCRIPTION
Tests will run on Xenial distribution Python 3.7, require tests pass on Python 3.7.