### PR TITLE
Development - fix default_avatar path. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Improved test coverage.
+### Changed
+- Bugfixes
+    - Fix path for default_avatar.
+    - Fix cwd set in TestDataFolder.test_generate_data_path_defaults to draw from ROOT_DIR.
+    - Fix bug - essentially blank (eg '_') chart name caused infinite loop. 
+    - Add '.png' to save filename, as it is not otherwise appended.
+- Major refactor of chart display and saving code.
+    - Fixes major bugs where blank image would be saved, app would hang indefinitely.
+    - Chart image now saves to app_data. Saved image is then displayed using Tkinter with a 'Save as' button. When this is pressed, image window disappears and os 'save as' dialogue is spawned, user can save where and as they choose.
+    - Pillow is used to process the image, resize it for display.
+- Add Pillow dependency, remove as yet unused numpy.
+
 
 ## [0.2.0-alpha] - 2018-12-31
 ### Added

--- a/dionysus_app/UI_menus/UI_functions.py
+++ b/dionysus_app/UI_menus/UI_functions.py
@@ -194,9 +194,18 @@ def select_folder_dialogue(title_str=None, start_dir='..'):
     return dir_path_str
 
 
-def display_image_save_as(chart_image_path):
+def display_image_save_as(chart_image_path: str):
+    """
+    Displays the given image path in a window titled with the filename.
+    Supplies a button "Save as" below, which quits the window. Save as
+    dialogue is called separately (ideally directly subsequently, from
+    a UI perspective.
+
+    :param chart_image_path: str or Path object.
+    :return: None
+    """
     root = tk.Tk()
-    root.title(Path(chart_image_path).name)  # adding Path() allows string or Path object.
+    root.title(Path(chart_image_path).name)  # Adding Path() allows string or Path object.
     root.geometry("960x580")  # Half dimensions, about a quarter of full image.
 
     image_display = ImageDisplay(image_path=chart_image_path, master=root)

--- a/dionysus_app/UI_menus/UI_functions.py
+++ b/dionysus_app/UI_menus/UI_functions.py
@@ -3,7 +3,11 @@ UI functions: user interface functions used throughout the application.
 """
 
 import tkinter as tk
+
+from pathlib import Path
 from tkinter import filedialog
+
+from PIL import ImageTk, Image
 
 
 def clear_screen(num_lines=50):
@@ -188,6 +192,47 @@ def select_folder_dialogue(title_str=None, start_dir='..'):
     if dir_path_str == '':
         return None
     return dir_path_str
+
+
+def display_image_save_as(chart_image_path):
+    root = tk.Tk()
+    root.title(Path(chart_image_path).name)  # adding Path() allows string or Path object.
+    root.geometry("960x580")  # Half dimensions, about a quarter of full image.
+
+    image_display = ImageDisplay(image_path=chart_image_path, master=root)
+    image_display.mainloop()
+
+    root.destroy()
+
+
+class ImageDisplay(tk.Frame):
+    def __init__(self, image_path=None, master=None):
+        super().__init__(master)
+        self.master = master
+
+        if image_path:
+            self.image_path = image_path
+            self.pack()
+            self.create_image_and_button()
+        else:
+            pass  # don't instantiate?
+
+    def create_image_and_button(self):
+        self.create_image_widget()
+        self.create_save_as_button_widget()
+
+    def create_image_widget(self):
+        self.full_chart_image = Image.open(self.image_path)
+        self.display_sized_image = self.full_chart_image.resize((960, 540), Image.ANTIALIAS)
+
+        self.display_image = ImageTk.PhotoImage(self.display_sized_image, master=self.master)
+        self.image_panel = tk.Label(self, image=self.display_image)
+        self.image_panel.pack(side="top", fill="both", expand="yes")
+
+    def create_save_as_button_widget(self):
+        self.quit = tk.Button(self, text="Save as", font=('Arial', 24),
+                              command=self.quit)
+        self.quit.pack(side="bottom")
 
 
 if __name__ == '__main__':

--- a/dionysus_app/chart_generator/generate_image.py
+++ b/dionysus_app/chart_generator/generate_image.py
@@ -24,6 +24,7 @@ CLASSLIST_DATA_PATH = DataFolder.generate_rel_path(DataFolder.CLASS_DATA.value)
 
 def generate_chart_image(chart_data_dict: dict):
     """
+    Create the chart image with given input.
 
     :param chart_data_dict: dict
     :return: None
@@ -95,7 +96,7 @@ def add_avatar_to_plot(ax, avatar_path, xy_coords: list):
 
 def validate_avatar(avatar_path):
     """
-
+    Validates the existence of the supplied path.
 
     :param avatar_path: Path
     :return: Path
@@ -169,7 +170,14 @@ def copy_image_to_user_save_loc(app_image_location, user_save_location):
 
 
 def get_user_save_chart_pathname(class_name: str, default_chart_name: str):
-
+    """
+    Calls save as dialogue to get user input for chart image file save
+    name and location. Supplies defaults, returns user chosen path
+    string.
+    :param class_name: str
+    :param default_chart_name: str
+    :return: str
+    """
     class_save_folder_path = Path(definitions.DEFAULT_CHART_SAVE_FOLDER).joinpath(class_name)
     class_save_folder_path.mkdir(parents=True, exist_ok=True)  # create class_save_folder if nonexistent
 

--- a/dionysus_app/chart_generator/generate_image.py
+++ b/dionysus_app/chart_generator/generate_image.py
@@ -4,8 +4,6 @@ Optional feature implementations:
 if title/name desired on image:
     fig.subtitle('title_string')
 """
-import os
-
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -17,7 +15,8 @@ import definitions
 from dionysus_app.chart_generator.process_chart_data import generate_avatar_coords
 from dionysus_app.class_functions import avatar_file_exists, DEFAULT_AVATAR_PATH
 from dionysus_app.data_folder import DataFolder
-from dionysus_app.UI_menus.UI_functions import save_as_dialogue
+from dionysus_app.file_functions import copy_file
+from dionysus_app.UI_menus.UI_functions import save_as_dialogue, display_image_save_as
 
 
 CLASSLIST_DATA_PATH = DataFolder.generate_rel_path(DataFolder.CLASS_DATA.value)
@@ -44,14 +43,21 @@ def generate_chart_image(chart_data_dict: dict):
 
     add_avatars_to_plot(ax, avatar_coord_dict)
 
-    # Maximise displayed image.
-    mng = plt.get_current_fig_manager()
-    mng.window.state("zoomed")
+    image_location = save_chart_image(chart_data_dict)
 
-    # Show image.
-    plt.show()
+    show_image(image_location)
 
-    save_chart_image(chart_data_dict)
+    user_save_chart_image(chart_data_dict, image_location)
+
+
+def show_image(image_location: str):
+    """
+    Calls show_image UI.
+
+    :param image_location: str or Path object.
+    :return: None
+    """
+    display_image_save_as(image_location)
 
 
 def set_axis(x_min: int=0, x_max: int=100, x_step: int=10):
@@ -116,23 +122,50 @@ def add_avatars_to_plot(ax, avatar_coord_dict: dict):
 
 def save_chart_image(chart_data_dict: dict):
     """
-    Save figure. Allow user to save to any filename, while saving to app_data/classname/chart_data with same filename \
-    as chart_name and chart_data_file name.
+    Save figure to app_data/classname/chart_data with same filename as
+    chart_name and chart_data_file name.
 
     :param chart_data_dict: dict
-    :return: None
+    :return: Path object
     """
 
     class_name = chart_data_dict['class_name']
     default_chart_name = chart_data_dict['chart_default_filename']
     app_data_save_pathname = Path(CLASSLIST_DATA_PATH).joinpath(class_name, 'chart_data', default_chart_name + '.png')
 
-    # save in app_data/class_data/class_name/chart_data with chart_default_filename
+    # Save in app_data/class_data/class_name/chart_data with chart_default_filename
     plt.savefig(app_data_save_pathname,
                 dpi=120)  # dpi - 120 comes to 1920*1080, 80 - 1280*720
-    # Save in user selected location with user defined name
-    plt.savefig(save_chart_pathname,
-                dpi=120)  # dpi - 120 comes to 1920*1080, 80 - 1280*720
+    return app_data_save_pathname
+
+
+def user_save_chart_image(chart_data_dict: dict, image_location: str):
+    """
+    Ask user for save location, defaulting to user default save folder
+    for class, with default chart filename. Copies image file from app's
+    save folder to users.
+
+    :param chart_data_dict: dict
+    :param image_location: str or Path object
+    :return: None
+    """
+    class_name = chart_data_dict['class_name']
+    default_chart_name = chart_data_dict['chart_default_filename']
+
+    # Save in user selected location with user defined name.
+    save_chart_pathname = get_user_save_chart_pathname(class_name, default_chart_name)
+    copy_image_to_user_save_loc(image_location, save_chart_pathname)
+
+
+def copy_image_to_user_save_loc(app_image_location, user_save_location):
+    """
+    Copies image from app_data location to user selected location.
+
+    :param app_image_location: str or Path object
+    :param user_save_location: str or Path object
+    :return: None
+    """
+    copy_file(app_image_location, user_save_location)
 
 
 def get_user_save_chart_pathname(class_name: str, default_chart_name: str):

--- a/dionysus_app/chart_generator/generate_image.py
+++ b/dionysus_app/chart_generator/generate_image.py
@@ -125,8 +125,7 @@ def save_chart_image(chart_data_dict: dict):
 
     class_name = chart_data_dict['class_name']
     default_chart_name = chart_data_dict['chart_default_filename']
-    app_data_save_pathname = Path(CLASSLIST_DATA_PATH).joinpath(class_name, 'chart_data', default_chart_name)
-    save_chart_pathname = get_user_save_chart_pathname(class_name, default_chart_name)
+    app_data_save_pathname = Path(CLASSLIST_DATA_PATH).joinpath(class_name, 'chart_data', default_chart_name + '.png')
 
     # save in app_data/class_data/class_name/chart_data with chart_default_filename
     plt.savefig(app_data_save_pathname,

--- a/dionysus_app/chart_generator/take_chart_data.py
+++ b/dionysus_app/chart_generator/take_chart_data.py
@@ -88,9 +88,11 @@ def take_chart_name():
 
     :return: str
     """
-    chart_name = input('Please enter a chart name/title: ')
+
     while True:
+        chart_name = input('Please enter a chart name/title: ')
         if input_is_essentially_blank(chart_name):
+            print('Please enter a valid chart name.')
             continue
         break
     return chart_name

--- a/dionysus_app/data_folder.py
+++ b/dionysus_app/data_folder.py
@@ -9,7 +9,9 @@ CHART_DATA_FILE_TYPE = '.cdf'
 
 
 class DataFolder(Enum):
-    APP_DATA = './dionysus_app/app_data/'
+    APP = 'dionysus_app/'
+
+    APP_DATA = APP + 'app_data/'
 
     CLASS_DATA = APP_DATA + 'class_data/'
 
@@ -18,7 +20,7 @@ class DataFolder(Enum):
     APP_SETTINGS = APP_DATA + 'settings.py'
     APP_DEFAULT_CHART_SAVE_FOLDER = '..'
 
-    CHART_GENERATOR = 'chart_generator/'
+    CHART_GENERATOR = APP + 'chart_generator/'
     DEFAULT_AVATAR = CHART_GENERATOR + 'default_avatar.png'
 
     @staticmethod

--- a/dionysus_app/data_folder.py
+++ b/dionysus_app/data_folder.py
@@ -9,7 +9,7 @@ CHART_DATA_FILE_TYPE = '.cdf'
 
 
 class DataFolder(Enum):
-    APP = 'dionysus_app/'
+    APP = './dionysus_app/'
 
     APP_DATA = APP + 'app_data/'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 matplotlib==3.0.2
-numpy==1.15.4
+Pillow=5.4.1
 setuptools==40.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 matplotlib==3.0.2
-Pillow=5.4.1
+Pillow==5.4.1
 setuptools==40.6.3

--- a/test_suite/test_data_folder.py
+++ b/test_suite/test_data_folder.py
@@ -1,7 +1,11 @@
 import os
 import unittest
 from pathlib import Path
+
+from class_registry_functions import write_registry_to_disk
 from dionysus_app.data_folder import DataFolder
+from initialise_app import data_folder_check
+from settings_functions import write_settings_to_file
 
 
 class TestDataFolder(unittest.TestCase):
@@ -28,3 +32,51 @@ class TestDataFolder(unittest.TestCase):
         path_result = DataFolder.generate_rel_path(None)
         cwd_path = Path.cwd().as_uri()  # cwd path OS agnostic for assertion
         assert cwd_path in path_result
+
+    def test_paths_exist(self):
+        for path in self.default_paths:
+            assert os.path.exists(path)
+
+class TestDataFolderPathsExist(unittest.TestCase):
+    def setUp(self):
+        """
+        Ensure file system and key files with paths in DataFolder exist.
+
+        This only semi-circular (ie x= value; assert value = x), because
+        the files are created by the code the app would normally use to
+        create these files, and if they're creating them in a place
+        other than at the specified paths, the test *should* fail.
+        """
+        # Create app file system, key files with paths in DataFolder
+        data_folder_check()  # App data folders
+
+        # Create dummy registry file if necessary
+        self.dummy_registry_file = False
+        self.registry_path = DataFolder.generate_rel_path(DataFolder.CLASS_REGISTRY.value)
+        if not os.path.exists(self.registry_path):
+            self.dummy_registry_file = True
+            registry_list = ['A_test_class', 'Another_test_class']
+            write_registry_to_disk(registry_list)
+
+        # Create dummy settings file if necessary
+        self.dummy_settings_file = False
+        self.settings_path = DataFolder.generate_rel_path(DataFolder.APP_SETTINGS.value)
+        if not os.path.exists(self.settings_path):
+            self.dummy_settings_file = True
+            settings_dict = {'There were': 'no settings set.'}
+            write_settings_to_file(settings_dict)
+
+
+    def test_paths_exist(self):
+        for path in DataFolder:
+                path = DataFolder.generate_rel_path(path.value)
+                assert os.path.exists(path)
+
+    def tearDown(self):
+        # Remove dummy files.
+        if self.dummy_registry_file:
+            os.remove(self.registry_path)
+        if self.dummy_settings_file:
+            os.remove(self.settings_path)
+
+

--- a/test_suite/test_data_folder.py
+++ b/test_suite/test_data_folder.py
@@ -2,10 +2,10 @@ import os
 import unittest
 from pathlib import Path
 
-from class_registry_functions import write_registry_to_disk
+from dionysus_app.class_registry_functions import write_registry_to_disk
 from dionysus_app.data_folder import DataFolder
-from initialise_app import data_folder_check
-from settings_functions import write_settings_to_file
+from dionysus_app.initialise_app import data_folder_check
+from dionysus_app.settings_functions import write_settings_to_file
 
 
 class TestDataFolder(unittest.TestCase):

--- a/test_suite/test_data_folder.py
+++ b/test_suite/test_data_folder.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from pathlib import Path
 
+from definitions import ROOT_DIR
 from dionysus_app.class_registry_functions import write_registry_to_disk
 from dionysus_app.data_folder import DataFolder
 from dionysus_app.initialise_app import data_folder_check
@@ -11,6 +12,8 @@ from dionysus_app.settings_functions import write_settings_to_file
 class TestDataFolder(unittest.TestCase):
 
     def setUp(self):
+        # set correct cwd:
+        os.chdir(ROOT_DIR)
         self.default_paths = [
             r'/dionysus_app'  
             r'/dionysus_app/app_data',
@@ -19,10 +22,10 @@ class TestDataFolder(unittest.TestCase):
             r'/dionysus_app/app_data/settings.py',
             r'/dionysus_app/chart_generator',
             r'/dionysus_app/chart_generator/default_avatar.png',
-        ]
+            ]
 
     def test_generate_data_path_defaults(self):
-        os.chdir(os.path.join(os.getcwd(), '..'))
+        os.chdir(ROOT_DIR)
         cwd_path = Path.cwd().as_uri()  # cwd path OS agnostic for assertion
         for path in self.default_paths:
             path_result = DataFolder.generate_rel_path(path).as_uri()
@@ -33,9 +36,6 @@ class TestDataFolder(unittest.TestCase):
         cwd_path = Path.cwd().as_uri()  # cwd path OS agnostic for assertion
         assert cwd_path in path_result
 
-    def test_paths_exist(self):
-        for path in self.default_paths:
-            assert os.path.exists(path)
 
 class TestDataFolderPathsExist(unittest.TestCase):
     def setUp(self):
@@ -66,7 +66,6 @@ class TestDataFolderPathsExist(unittest.TestCase):
             settings_dict = {'There were': 'no settings set.'}
             write_settings_to_file(settings_dict)
 
-
     def test_paths_exist(self):
         for path in DataFolder:
                 path = DataFolder.generate_rel_path(path.value)
@@ -78,5 +77,3 @@ class TestDataFolderPathsExist(unittest.TestCase):
             os.remove(self.registry_path)
         if self.dummy_settings_file:
             os.remove(self.settings_path)
-
-


### PR DESCRIPTION
- Major refactor of chart display and saving code.
    - Fixes major bugs where blank image would be saved, app would hang indefinitely.
    - Chart image now saves to app_data. Saved image is then displayed using Tkinter with a 'Save as' button. When this is pressed, image window disappears and os 'save as' dialogue is spawned, user can save where and as they choose.
    - Add `display_image_save_as`, `ImageDisplay` class to `UI_functions.py`.
    - Pillow is used to process the image, resize it for display.

Other changes:
  - Add Pillow dependency, remove as yet unused numpy.
  - Fix path for default_avatar, add tests asserting that paths in DataFolder exist.
  - Fix `cwd` set in `TestDataFolder.test_generate_data_path_defaults` to draw from `ROOT_DIR`.
  - Fix bug - essentially blank (eg '_') chart name causing infinite loop. 
  - Add '.png' to save filename, as it is not otherwise appended. This facilitated passing of the app_save filename to the image display without throwing a file not found error. 
  - Docstring creation/improvements.

