### PR TITLE
Fix circleci test metadata storage. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,10 @@ jobs:
                 command: |
                     . venv/bin/activate
                     mkdir test-reports
-                    pytest -v --cov=/home/circleci/dionysus/ --junitxml=../test-results/junit.xml
-                    coverage xml
+                    pytest --junitxml=test-reports/junit.xml
 
             - store_test_results:
-                path: test-results
+                path: test-reports
 
             - store_artifacts:
                 path: test-reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved test coverage. 
 #### Changed
 - Fix bug in save_as_dialogue that failed with TypeError when called without filetypes parameter or with default filetypes=None.
+- Fix circleci not storing test metadata.
 
 ## [0.3.0-alpha] - 2019-01-23
 ### Added

--- a/test_suite/UI_menus_tests/test_UI_functions.py
+++ b/test_suite/UI_menus_tests/test_UI_functions.py
@@ -188,7 +188,7 @@ class TestScrubCandidateFilename(TestCase):
 
                 assert scrub_candidate_filename(test_input) == expected_output
 
-@patch('dionysus_app.UI_menus.UI_functions.tk.Tk')
+# @patch('dionysus_app.UI_menus.UI_functions.tk.Tk')
 class TestSaveAsDialogue(TestCase):
     def setUp(self):
         self.default_filetypes = [("all files", "*.*")]

--- a/test_suite/UI_menus_tests/test_UI_functions.py
+++ b/test_suite/UI_menus_tests/test_UI_functions.py
@@ -188,7 +188,7 @@ class TestScrubCandidateFilename(TestCase):
 
                 assert scrub_candidate_filename(test_input) == expected_output
 
-# @patch('dionysus_app.UI_menus.UI_functions.tk.Tk')
+@patch('dionysus_app.UI_menus.UI_functions.tk.Tk')
 class TestSaveAsDialogue(TestCase):
     def setUp(self):
         self.default_filetypes = [("all files", "*.*")]


### PR DESCRIPTION
Fix circleci issue ot storing metadata by removing pytest-cov/coveralls 
from test script (these are already reported by TravisCI), and correct
circleci test_results path to match documentation.