### PR TITLE
Development - refactor application exit, main_menu, add tests. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Move `quit_app` to `app_main`, have `quit_app` call `check_registry_on_exit` before call to `sys.exit`.
     - Refactor `main_menu` and `take_main_menu_input` to use flag for exit call. `take_main_menu_input` returns `True` instead of `None` if use chooses to quit. 
 - Simplify loop in `take_main_menu_input` preferring `if; if` over `if elif else`.
+### Fixed
+- `check_registry_on_exit` is now called on exit. Previously was called after `sys.exit` and not run. 
 
 ## [0.3.1-alpha] - 2019-02-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Move fetching of student data into `if` clause, fetch only if student has a score.
     - Simplify conditional to only filter out scores of `None` rather than chained conditional testing for values evaluating to `True` or `0`.
 - Chart generation test scripts moved to dedicated folder in `test_suite`.
-- Refactor application exit:
+- Refactor application exit, `main_menu`:
     - Move `quit_app` to `app_main`, have `quit_app` call `check_registry_on_exit` before call to `sys.exit`.
     - Refactor `main_menu` and `take_main_menu_input` to use flag for exit call. `take_main_menu_input` returns `True` instead of `None` if use chooses to quit. 
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Improved test coverage.
 ### Changed
-- Implementation of take_student_scores:
+- Implementation of `take_student_scores`:
     - Move fetching of student data into `if` clause, fetch only if student has a score.
     - Simplify conditional to only filter out scores of `None` rather than chained conditional testing for values evaluating to `True` or `0`.
-- Chart generation test scripts moved to dedicated folder in test_suite.
+- Chart generation test scripts moved to dedicated folder in `test_suite`.
+- Refactor application exit:
+    - Move `quit_app` to `app_main`, have `quit_app` call `check_registry_on_exit` before call to `sys.exit`.
+    - Refactor `main_menu` and `take_main_menu_input` to use flag for exit call. `take_main_menu_input` returns `True` instead of `None` if use chooses to quit. 
+    
 
 ## [0.3.1-alpha] - 2019-02-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor application exit, `main_menu`:
     - Move `quit_app` to `app_main`, have `quit_app` call `check_registry_on_exit` before call to `sys.exit`.
     - Refactor `main_menu` and `take_main_menu_input` to use flag for exit call. `take_main_menu_input` returns `True` instead of `None` if use chooses to quit. 
-    
+- Simplify loop in `take_main_menu_input` preferring `if; if` over `if elif else`.
 
 ## [0.3.1-alpha] - 2019-02-06
 ### Added

--- a/app_main.py
+++ b/app_main.py
@@ -14,6 +14,8 @@ from dionysus_app.settings_functions import load_chart_save_folder
 
 def quit_app():
     """
+    Checks disk registry, rewrites if inconsistent with runtime registry
+    (eg if user has deleted files during runtime), quits application.
 
     :return: None
     """

--- a/app_main.py
+++ b/app_main.py
@@ -12,6 +12,15 @@ from dionysus_app.UI_menus.main_menu import run_main_menu
 from dionysus_app.settings_functions import load_chart_save_folder
 
 
+def quit_app():
+    """
+
+    :return: None
+    """
+    check_registry_on_exit()  # Dump cached registry to disk if different class_registry.index.
+    sys.exit()
+
+
 def run_app():
     """
     Env/system checks. Data setup.
@@ -31,7 +40,7 @@ def run_app():
 
     run_main_menu()  # Startup checks successful, enter UI.
 
-    check_registry_on_exit()  # Dump cached registry to disk if different class_registry.index.
+    quit_app()
 
 
 if __name__ == "__main__":

--- a/dionysus_app/UI_menus/main_menu.py
+++ b/dionysus_app/UI_menus/main_menu.py
@@ -68,7 +68,3 @@ def run_main_menu():
         quit_app = take_main_menu_input()
         if quit_app:
             break
-
-
-if __name__ == "__main__":
-    run_main_menu()

--- a/dionysus_app/UI_menus/main_menu.py
+++ b/dionysus_app/UI_menus/main_menu.py
@@ -13,13 +13,14 @@ def welcome_blurb():
 
 def main_menu_options():
     print("Dionysus - Main menu\n")
-    print("Please select an option by entering the corresponding number, and press return:\n"
-          "     1. Create a classlist\n"
+    print("Please select an option by entering the corresponding number, and press return:\n")
+    print("     1. Create a classlist\n"
           "     2. Edit a classlist\n"
           "     3. Create a new chart\n"
           "     \n"
           "     9. Settings\n"
-          "     Enter Q to quit.\n")
+          "     Enter Q to quit.\n"
+          )
 
 
 def take_main_menu_input():

--- a/dionysus_app/UI_menus/main_menu.py
+++ b/dionysus_app/UI_menus/main_menu.py
@@ -1,9 +1,6 @@
 """
 Application main menu.
 """
-
-import sys
-
 from dionysus_app.class_functions import create_classlist
 from dionysus_app.chart_generator.create_chart import new_chart
 from dionysus_app.UI_menus.edit_class_data_UI import edit_class_data
@@ -51,10 +48,6 @@ def take_main_menu_input():
             unselected = False  # Exiting the loop when chosen action finishes.
         else:
             print("Invalid input.")
-
-
-def quit_app():
-    sys.exit()
 
 
 # Create a classlist

--- a/dionysus_app/UI_menus/main_menu.py
+++ b/dionysus_app/UI_menus/main_menu.py
@@ -36,9 +36,8 @@ def take_main_menu_input():
         '2': edit_class_data,
         '3': new_chart,
         '9': run_settings_menu,
-        'q': quit_app,
-        'Q': quit_app,
         }
+
     unselected = True
     while unselected:
         chosen_option = input('>>> ')
@@ -46,6 +45,8 @@ def take_main_menu_input():
         if chosen_option in possible_options:
             possible_options[chosen_option]()
             unselected = False  # Exiting the loop when chosen action finishes.
+        elif chosen_option.upper() == 'Q':
+            return True  # Quit app.
         else:
             print("Invalid input.")
 
@@ -63,8 +64,9 @@ def run_main_menu():
 
     while True:
         main_menu_options()
-        take_main_menu_input()
-    quit_app()
+        quit_app = take_main_menu_input()
+        if quit_app:
+            break
 
 
 if __name__ == "__main__":

--- a/dionysus_app/UI_menus/main_menu.py
+++ b/dionysus_app/UI_menus/main_menu.py
@@ -39,17 +39,15 @@ def take_main_menu_input():
         '9': run_settings_menu,
         }
 
-    unselected = True
-    while unselected:
+    while True:
         chosen_option = input('>>> ')
 
         if chosen_option in possible_options:
             possible_options[chosen_option]()
-            unselected = False  # Exiting the loop when chosen action finishes.
-        elif chosen_option.upper() == 'Q':
+            break  # Exit  loop when chosen action finishes.
+        if chosen_option.upper() == 'Q':
             return True  # Quit app.
-        else:
-            print("Invalid input.")
+        print("Invalid input.")  # User input does not correspond to option or exit.
 
 
 # Create a classlist

--- a/test_suite/UI_menus_tests/test_main_menu.py
+++ b/test_suite/UI_menus_tests/test_main_menu.py
@@ -1,0 +1,132 @@
+from unittest import TestCase, mock
+from unittest.mock import patch
+
+from dionysus_app.UI_menus.main_menu import (main_menu_options,
+                                             run_main_menu,
+                                             take_main_menu_input,
+                                             welcome_blurb,
+                                             )
+
+
+class TestWelcomeBlurb(TestCase):
+    def setUp(self):
+        self.welcome_blurb_print_stmt = "Welcome to Dionysus - student avatar chart generator\n"
+
+    @patch('dionysus_app.UI_menus.main_menu.print')
+    def test_welcome_blurb(self, mocked_print):
+        assert welcome_blurb() is None
+        mocked_print.assert_called_once_with(self.welcome_blurb_print_stmt)
+
+
+class TestMainMenuOptions(TestCase):
+    def setUp(self):
+        self.menu_print_stmts = ["Dionysus - Main menu\n",
+                                 "Please select an option by entering the corresponding number, and press return:\n",
+                                 "     1. Create a classlist\n"
+                                 "     2. Edit a classlist\n"
+                                 "     3. Create a new chart\n"
+                                 "     \n"
+                                 "     9. Settings\n"
+                                 "     Enter Q to quit.\n",
+                                 ]
+
+    @patch('dionysus_app.UI_menus.main_menu.print')
+    def test_main_menu_options(self, mocked_print):
+        assert main_menu_options() is None
+        assert mocked_print.call_args_list == [mock.call(print_stmt) for print_stmt in self.menu_print_stmts]
+
+
+class TestTakeMainMenuInput(TestCase):
+    def setUp(self):
+        self.quit_inputs = ['q',
+                            'Q',
+                            ]
+        self.valid_input_option_mock = [('1', 'dionysus_app.UI_menus.main_menu.create_classlist'),
+                                        ('2', 'dionysus_app.UI_menus.main_menu.edit_class_data'),
+                                        ('3', 'dionysus_app.UI_menus.main_menu.new_chart'),
+                                        ('9', 'dionysus_app.UI_menus.main_menu.run_settings_menu'),
+                                        ]
+
+        self.invalid_inputs = ['',  # No input, return pressed.
+                               ' ',  # Space/blank input.
+                               'slightly_silly',  # Bad string input.
+                               '0',  # Zero input.
+                               '1.0'  # Float of valid input.
+                               '-2',  # Negative valid option input.
+                               '99',  # Out of range int input.
+                               ]
+        self.final_valid_input = ['Q']  # Mock a valid input to call quit_app.
+
+        self.bad_input_user_inputs = self.invalid_inputs + self.final_valid_input
+
+        self.invalid_input_print_stmt = 'Invalid input.'
+
+    @patch('dionysus_app.UI_menus.main_menu.input')
+    def test_take_main_menu_input_quit(self, mocked_input):
+        for quit_input in self.quit_inputs:
+            with self.subTest(msg=f'Quit input {quit_input} should return True.'):
+                mocked_input.return_value = quit_input
+
+                assert take_main_menu_input() is True
+
+    @patch('dionysus_app.UI_menus.main_menu.input')
+    def test_take_main_menu_input_non_quit_option_selected(self, mocked_input):
+        for user_input, called_function in self.valid_input_option_mock:
+            with self.subTest(msg=f'input={user_input}, should call {called_function}'
+                              ), patch(called_function) as mock_called_option:
+                mocked_input.return_value = user_input
+
+                # Returns None when feature function is called.
+                assert take_main_menu_input() is None
+
+                mock_called_option.assert_called_once()
+
+                mocked_input.reset_mock(return_value=True)
+
+    @patch('dionysus_app.UI_menus.main_menu.print')
+    @patch('dionysus_app.UI_menus.main_menu.input')
+    def test_take_main_menu_input_bad_input(self, mocked_input, mocked_print):
+        mocked_input.side_effect = self.bad_input_user_inputs
+
+        assert take_main_menu_input() is True  # Final return valid quit input.
+        assert mocked_print.call_args_list == [mock.call(self.invalid_input_print_stmt)
+                                               for invalid_input in self.invalid_inputs]
+
+
+class TestRunMainMenu(TestCase):
+    def setUp(self):
+        self.valid_input_to_quit = 'Q'  # Mock a valid input to call quit_app.
+
+    @patch('dionysus_app.UI_menus.main_menu.take_main_menu_input')  # Mock call to take_main_menu_input.
+    @patch('dionysus_app.UI_menus.main_menu.main_menu_options')  # Mock call to main_menu_options.
+    @patch('dionysus_app.UI_menus.main_menu.welcome_blurb')  # Mock call to welcome_blurb.
+    def test_run_main_menu(self,
+                           mocked_welcome_blurb,
+                           mocked_main_menu_options,
+                           mocked_take_main_menu_input,
+                           ):
+        take_main_menu_input_returns = [None, None, True]
+        mocked_take_main_menu_input.side_effect = take_main_menu_input_returns  # 2 mock feature calls, call to quit.
+
+        assert run_main_menu() is None
+
+        mocked_welcome_blurb.assert_called_once()
+
+        main_menu_calls = [mock.call() for each_call in take_main_menu_input_returns]
+        assert mocked_main_menu_options.call_args_list == main_menu_calls
+        assert mocked_take_main_menu_input.call_args_list == main_menu_calls
+
+    @patch('dionysus_app.UI_menus.main_menu.main_menu_options')  # Mock call to main_menu_options.
+    @patch('dionysus_app.UI_menus.main_menu.welcome_blurb')  # Mock call to welcome_blurb.
+    @patch('dionysus_app.UI_menus.main_menu.input')
+    def test_run_main_menu_call_unmocked_take_menu_input(self,
+                                                         mocked_input,
+                                                         mocked_welcome_blurb,
+                                                         mocked_main_menu_options,
+                                                         ):
+        mocked_input.return_value = self.valid_input_to_quit
+
+        assert run_main_menu() is None
+
+        mocked_welcome_blurb.assert_called_once()
+        mocked_main_menu_options.assert_called_once()

--- a/test_suite/test_app_main.py
+++ b/test_suite/test_app_main.py
@@ -1,0 +1,15 @@
+"""Test app_main."""
+
+from unittest import TestCase, mock
+from unittest.mock import patch
+
+from app_main import quit_app
+
+
+class TestQuitApp(TestCase):
+    @patch('app_main.sys.exit')
+    @patch('app_main.check_registry_on_exit')
+    def test_quit_app(self, mock_check_registry_on_exit, mock_exit_call):
+        assert quit_app() is None
+        mock_check_registry_on_exit.assert_called_once()
+        mock_exit_call.assert_called_once()


### PR DESCRIPTION
- Refactor application exit, main_menu.
    - Move quit_app to app_main, call outside run_main_menu.
    - Wrap call to check_registry_on_exit in quit_app.
    - Refactor take_main_menu_input, run_main_menu to use quit flag.  
Remove call to quit_app, take_main_menu_input returns flag to indicate
user quit, which is checked by run_main_menu, breaking out of the loop
if the flag is True.
    - Simplify `take_main_menu_input` loop.
- Add tests:
    - Add tests for main_menu. 
    - Add test for quit_app in app_main. 