### PR TITLE
Object orient select_student, new test coverage, type hints. 

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+{
+  "generalSettings": {
+    "shouldScanRepo": true
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed implementation of `UI_functions.scrub_candiate_filename` to replace removed characters with `'_'` - this means 'Ni/' and 'Ni' will render non-identically as 'Ni_' and 'Ni'
 - Factored out `create_app_data__init__` from `create_app_settings_file`.
 - Use development branch as target for pyup.io dependency updates.
-- Update dependencies. 
-
+- Update dependencies.
 - Progress conforming all path passing to use `Path` objects - in particular casting path str to `Path` before returning from GUI filedialogs. `load_chart_save_folder` now also returns `Path` object.
 ### Depreciated
 - `class_functions.create_student_list_dict`: unused function loads class from disk to return an enumerated student list. Function is thus unnecessary when replaced by one-lined: `{numeral: student.name for numeral, student in enumerate(c.students, start=1)}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Improved test coverage.
 ### Changed
 - `select_student` now uses Class object, returns Student object.
 - `file_functions` tests now all use new-style class data. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `--f`/`--filepath=path_to_file`: Process single file at path given to arg.
 - Improved test coverage.
 ### Changed
-- Changed data file data format reflecting use of objects rather than dictionaries.
+- Changed data file data format reflecting serialised objects rather than dictionaries.
     - Core differences: 
         - the class' `name` is a key in the json dict
         - `students` is a key with a list of json-ified student objects
         - data (eg avatars) that is `None` is not saved to disk, but inferred on instantiation.
+    - Reinstantiation to object rather than dict allows easy modification, additional attributes, change of data format or implementation of a database to be non-breaking changes.
 - Changed implementation of `UI_functions.scrub_candiate_filename` to replace removed characters with `'_'` - this means 'Ni/' and 'Ni' will render non-identically as 'Ni_' and 'Ni'
 - Factored out `create_app_data__init__` from `create_app_settings_file`.
-- Use development branch as target for pyup.io dependency updates.
-- Update dependencies.
+- Changed target for pyup.io dependency updates to development branch.
+- Updated dependencies.
 - Progress conforming all path passing to use `Path` objects - in particular casting path str to `Path` before returning from GUI filedialogs. `load_chart_save_folder` now also returns `Path` object.
 ### Depreciated
 - `class_functions.create_student_list_dict`: unused function loads class from disk to return an enumerated student list. Function is thus unnecessary when replaced by one-lined: `{numeral: student.name for numeral, student in enumerate(c.students, start=1)}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `select_student` now uses Class object, returns Student object.
 - `file_functions` tests now all use new-style class data. 
+### Depreciated
+- Use of old-style data format in `testing_class_data` 
 ### Removed
 - `class_functions.create_student_list_dict`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- `select_student` now uses Class object, returns Student object.
+### Removed
+- `class_functions.create_student_list_dict`
+
 ## [0.4.0-alpha] - 2019-05-22
 ### Added
 - Class and Student objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - `select_student` now uses Class object, returns Student object.
+- `file_functions` tests now all use new-style class data. 
 ### Removed
 - `class_functions.create_student_list_dict`
 

--- a/definitions.py
+++ b/definitions.py
@@ -7,4 +7,4 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))  # Global root directory.
 
 REGISTRY: Optional[List] = None
 
-DEFAULT_CHART_SAVE_FOLDER: Optional[Path] = None  # Path object.
+DEFAULT_CHART_SAVE_FOLDER: Path = None  # Path object.

--- a/dionysus_app/UI_menus/chart_generator/create_chart_UI.py
+++ b/dionysus_app/UI_menus/chart_generator/create_chart_UI.py
@@ -6,14 +6,14 @@ from PIL import Image, ImageTk
 from dionysus_app.UI_menus.UI_functions import save_as_dialogue
 
 
-def save_chart_dialogue(default_chart_name: str, class_save_folder_path):
+def save_chart_dialogue(default_chart_name: str, class_save_folder_path: Path):
     """
     Calls save as dialogue to get user input for chart image file save
     name and location. Supplies defaults, returns user chosen path
     string.
 
     :param default_chart_name: str
-    :param class_save_folder_path: Path or str
+    :param class_save_folder_path: Path
     :return: str
     """
     class_save_folder_str = str(class_save_folder_path)
@@ -25,18 +25,18 @@ def save_chart_dialogue(default_chart_name: str, class_save_folder_path):
     return save_chart_path_str
 
 
-def display_image_save_as(chart_image_path: str):
+def display_image_save_as(chart_image_path: Path):
     """
     Displays the given image path in a window titled with the filename.
     Supplies a button "Save as" below, which quits the window. Save as
     dialogue is called separately (ideally directly subsequently, from
     a UI perspective.
 
-    :param chart_image_path: str or Path object.
+    :param chart_image_path: Path object.
     :return: None
     """
     root = tk.Tk()
-    root.title(Path(chart_image_path).name)  # Adding Path() allows string or Path object.
+    root.title(chart_image_path.name)
     root.geometry("960x580")  # Half dimensions, about a quarter of full image.
 
     image_display = ImageDisplay(image_path=chart_image_path, master=root)
@@ -46,7 +46,7 @@ def display_image_save_as(chart_image_path: str):
 
 
 class ImageDisplay(tk.Frame):
-    def __init__(self, image_path=None, master=None):
+    def __init__(self, image_path: Path = None, master=None):
         super().__init__(master)
         self.master = master
 

--- a/dionysus_app/UI_menus/class_functions_UI.py
+++ b/dionysus_app/UI_menus/class_functions_UI.py
@@ -152,6 +152,7 @@ def take_student_selection(student_options: dict):
             break
 
         except (KeyError, ValueError):
+            # Case where user typed in name of student.
             if chosen_option in student_options.values():
                 selected_student = chosen_option
                 break

--- a/dionysus_app/chart_generator/create_chart.py
+++ b/dionysus_app/chart_generator/create_chart.py
@@ -181,14 +181,14 @@ def sanitise_avatar_path_objects(data_dict: dict):
     return data_dict
 
 
-def user_save_chart_image(chart_data_dict: dict, image_location: str):
+def user_save_chart_image(chart_data_dict: dict, image_location: Path):
     """
     Ask user for save location, defaulting to user default save folder
     for class, with default chart filename. Copies image file from app's
     save folder to users.
 
     :param chart_data_dict: dict
-    :param image_location: str or Path object
+    :param image_location: Path object
     :return: None
     """
     class_name = chart_data_dict['class_name']
@@ -199,12 +199,12 @@ def user_save_chart_image(chart_data_dict: dict, image_location: str):
     copy_image_to_user_save_loc(image_location, save_chart_pathname)
 
 
-def copy_image_to_user_save_loc(app_image_location, user_save_location):
+def copy_image_to_user_save_loc(app_image_location: Path, user_save_location: Path):
     """
     Copies image from app_data location to user selected location.
 
-    :param app_image_location: str or Path object
-    :param user_save_location: str or Path object
+    :param app_image_location: Path object
+    :param user_save_location: Path object
     :return: None
     """
     copy_file(app_image_location, user_save_location)
@@ -254,11 +254,11 @@ def get_class_save_folder_path(class_name: str):
     return class_save_folder_path
 
 
-def show_image(image_location: str):
+def show_image(image_location: Path):
     """
     Calls show_image UI.
 
-    :param image_location: str or Path object.
+    :param image_location: Path object.
     :return: None
     """
     display_image_save_as(image_location)

--- a/dionysus_app/chart_generator/generate_image.py
+++ b/dionysus_app/chart_generator/generate_image.py
@@ -17,12 +17,12 @@ from dionysus_app.data_folder import DataFolder
 CLASSLIST_DATA_PATH = DataFolder.generate_rel_path(DataFolder.CLASS_DATA.value)
 
 
-def generate_chart_image(chart_data_dict: dict):
+def generate_chart_image(chart_data_dict: dict) -> Path:
     """
-    Create the chart image with given input.
+    Create the chart image with given input, return image Path.
 
     :param chart_data_dict: dict
-    :return: None
+    :return: Path object
     """
     fig = plt.figure(figsize=(16, 9))  # set proportion/size in inches,
     ax = plt.subplot(xlim=(-0, 105), ylim=(-0, 100))
@@ -49,7 +49,7 @@ def set_axis(x_min: int=0, x_max: int=100, x_step: int=10):
     plt.yticks([])
 
 
-def add_avatar_to_plot(ax, avatar_path, xy_coords: list):
+def add_avatar_to_plot(ax, avatar_path, xy_coords: list) -> None:
     """
     Takes an image path and adds that image to the ax given, at each set of coordinates in the list supplied.
 
@@ -60,7 +60,7 @@ def add_avatar_to_plot(ax, avatar_path, xy_coords: list):
     :param ax:
     :param avatar_path: Path object
     :param xy_coords: list - list of tuples (x, y)
-    :return:
+    :return: None
     """
     valid_avatar_path = validate_avatar(avatar_path)
 

--- a/dionysus_app/class_functions.py
+++ b/dionysus_app/class_functions.py
@@ -221,15 +221,15 @@ def create_class_list_dict():
     return class_dict
 
 
-def select_student(class_name: str):
+def select_student(current_class: Class):
     """
     Display list of students in class and allow user to select one, returning the name of the
     selected student.
 
-    :param class_name: str
+    :param class_name: Class object
     :return: str
     """
-    student_options = create_student_list_dict(class_name)
+    student_options = {numeral: student.name for numeral, student in enumerate(current_class.students, start=1)}
     display_student_selection_menu(student_options)
 
     selected_student = take_student_selection(student_options)

--- a/dionysus_app/class_functions.py
+++ b/dionysus_app/class_functions.py
@@ -223,18 +223,18 @@ def create_class_list_dict():
 
 def select_student(current_class: Class):
     """
-    Display list of students in class and allow user to select one, returning the name of the
-    selected student.
+    Display list of students in class and allow user to select one, returning
+    the selected Student object.
 
     :param class_name: Class object
-    :return: str
+    :return: Student_object
     """
     student_options = {numeral: student.name for numeral, student in enumerate(current_class.students, start=1)}
     display_student_selection_menu(student_options)
 
-    selected_student = take_student_selection(student_options)
+    selected_student_name = take_student_selection(student_options)
 
-    return selected_student
+    return next(student for student in current_class.students if student.name == selected_student_name)
 
 
 def load_class_from_disk(class_name: str):

--- a/dionysus_app/class_functions.py
+++ b/dionysus_app/class_functions.py
@@ -226,7 +226,7 @@ def select_student(current_class: Class):
     Display list of students in class and allow user to select one, returning
     the selected Student object.
 
-    :param class_name: Class object
+    :param current_class: Class object
     :return: Student_object
     """
     student_options = {numeral: student.name for numeral, student in enumerate(current_class.students, start=1)}

--- a/dionysus_app/class_functions.py
+++ b/dionysus_app/class_functions.py
@@ -237,22 +237,6 @@ def select_student(current_class: Class):
     return selected_student
 
 
-def create_student_list_dict(class_name: str):
-    """
-    Create dict with enumerated students, starting at 1.
-
-    CONSIDER DEPRECIATED GOING FORWARD, as for most all use cases, class will
-    already be loaded when this is needed.
-
-    :param class_name: str
-    :return: dict
-    """
-    loaded_class = load_class_from_disk(class_name)
-    student_list_dict = {option: student.name
-                         for option, student in enumerate(loaded_class.students, start=1)}
-    return student_list_dict
-
-
 def load_class_from_disk(class_name: str):
     """
     Load class data from a class data ('.cld') file, return Class object.

--- a/dionysus_app/class_functions.py
+++ b/dionysus_app/class_functions.py
@@ -234,7 +234,8 @@ def select_student(current_class: Class):
 
     selected_student_name = take_student_selection(student_options)
 
-    return next(student for student in current_class.students if student.name == selected_student_name)
+    return next(student for student in current_class.students
+                if student.name == selected_student_name)
 
 
 def load_class_from_disk(class_name: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-matplotlib==3.0.3
+matplotlib==3.1.0
 Pillow==6.0.0
 setuptools==41.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,5 +5,5 @@ pytest==4.6.2
 codacy-coverage==1.3.11
 codecov==2.0.15
 coverage==4.5.3
-coveralls==1.7.0
+coveralls==1.8.0
 pytest-cov==2.7.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 pexpect==4.7.0
-pytest==4.4.1
+pytest==4.6.2
 
 # Running tests on Travis
 codacy-coverage==1.3.11

--- a/test_suite/UI_menus_tests/test_class_functions_UI.py
+++ b/test_suite/UI_menus_tests/test_class_functions_UI.py
@@ -394,7 +394,7 @@ class TestTakeStudentSelection(TestCase):
         self.valid_numerical_inputs = [(str(key), self.test_class_student_options[key])
                                        for key in self.test_class_student_options.keys()]
         # Exact class name
-        self.valid_string_inputs = [(class_name, class_name) for class_name in self.test_class_student_options.values()]
+        self.valid_string_inputs = [(student_name, student_name) for student_name in self.test_class_student_options.values()]
 
         self.blank_junk_inputs = [self.no_input,
                                   self.space_input,

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -31,7 +31,11 @@ class TestNewChart:
         test_chart_image_location = 'some image location'
 
         def mocked_assemble_chart_data():
-            return test_class_name, test_chart_name, test_chart_default_filename, test_score_avatar_dict, test_chart_params
+            return (test_class_name,
+                    test_chart_name,
+                    test_chart_default_filename,
+                    test_score_avatar_dict,
+                    test_chart_params)
 
         def mocked_write_chart_data_to_file(chart_data_dict):
             if chart_data_dict != test_chart_data_dict:

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -13,7 +13,7 @@ from dionysus_app.data_folder import CHART_DATA_FILE_TYPE
 from test_suite.testing_class_data import test_full_class_data_set
 
 
-class TestTakeStudentScores:
+class TestNewChart:
     def test_new_chart(self, monkeypatch):
         test_class_name = 'test_class_name'
         test_chart_name = 'test_chart_name'

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -50,8 +50,8 @@ class TestTakeStudentScores:
         monkeypatch.setattr(create_chart, 'generate_chart_image', mocked_generate_chart_image)
         monkeypatch.setattr(create_chart, 'show_image', mocked_show_image)
         monkeypatch.setattr(create_chart, 'user_save_chart_image', mocked_user_save_chart_image)
-        def test_new_chart(self):
-            assert new_chart() is None
+
+        assert new_chart() is None
 
 
 class TestGetCustomChartOptions(TestCase):

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -5,8 +5,10 @@ from dionysus_app.chart_generator import create_chart
 from dionysus_app.chart_generator.create_chart import (assemble_chart_data,
                                                        get_custom_chart_options,
                                                        new_chart,
-                                                       write_chart_data_to_file
+                                                       set_chart_params,
+                                                       write_chart_data_to_file,
                                                        )
+from dionysus_app.chart_generator.process_chart_data import DEFAULT_CHART_PARAMS
 from dionysus_app.class_ import Class
 from dionysus_app.data_folder import CHART_DATA_FILE_TYPE
 
@@ -143,6 +145,20 @@ class TestWriteChartDataToFile:
         assert test_filepath.exists()
         with open(test_filepath, 'r') as test_file:
             assert test_file.read() == test_text_written_to_file
+
+
+class TestSetChartParams:
+    def test_set_chart_params(self, monkeypatch):
+        test_params = {'some': 'params'}
+
+        def mocked_get_custom_chart_options(default_options):
+            if default_options != DEFAULT_CHART_PARAMS:
+                raise ValueError
+            return test_params
+
+        monkeypatch.setattr(create_chart, 'get_custom_chart_options', mocked_get_custom_chart_options)
+
+        assert set_chart_params() == test_params
 
 
 class TestGetCustomChartOptions(TestCase):

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from dionysus_app.chart_generator import create_chart
-from dionysus_app.chart_generator.create_chart import (get_custom_chart_options,
+from dionysus_app.chart_generator.create_chart import (assemble_chart_data,
+                                                       get_custom_chart_options,
                                                        new_chart,
                                                        write_chart_data_to_file
                                                        )

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 from dionysus_app.chart_generator import create_chart
 from dionysus_app.chart_generator.create_chart import (get_custom_chart_options,
                                                        new_chart,
-                                                       )
+                                                       assemble_chart_data)
+from dionysus_app.class_ import Class
+
+from test_suite.testing_class_data import test_full_class_data_set
+
 
 class TestTakeStudentScores:
     def test_new_chart(self, monkeypatch):
@@ -52,6 +56,47 @@ class TestTakeStudentScores:
         monkeypatch.setattr(create_chart, 'user_save_chart_image', mocked_user_save_chart_image)
 
         assert new_chart() is None
+
+
+class TestAssembleChartData:
+    def test_assemble_chart_data(self, monkeypatch):
+        test_class = Class.from_dict(test_full_class_data_set['json_dict_rep'])
+        test_class_name = test_class.name
+        test_chart_name = 'my_chart'
+        test_chart_filename = test_chart_name
+        mock_score_avatar_dict = {'scores': 'list of avatars'}
+        mock_chart_params = {'some': 'chart_params'}
+
+        def mocked_select_classlist():
+            return test_class_name
+
+        def mocked_load_class_from_disk(class_name):
+            assert class_name == test_class_name
+            return test_class
+
+        def mocked_take_score_data(class_obj):
+            assert class_obj is test_class
+            return mock_score_avatar_dict
+
+        def mocked_take_chart_name():
+            return test_chart_name
+
+        def mocked_clean_for_filename(chart_name):
+            assert chart_name == test_chart_name
+            return test_chart_name
+
+        def mocked_set_chart_params():
+            return mock_chart_params
+
+        monkeypatch.setattr(create_chart, 'select_classlist', mocked_select_classlist)
+        monkeypatch.setattr(create_chart, 'load_class_from_disk', mocked_load_class_from_disk)
+        monkeypatch.setattr(create_chart, 'take_score_data', mocked_take_score_data)
+        monkeypatch.setattr(create_chart, 'take_chart_name', mocked_take_chart_name)
+        monkeypatch.setattr(create_chart, 'clean_for_filename', mocked_clean_for_filename)
+        monkeypatch.setattr(create_chart, 'set_chart_params', mocked_set_chart_params)
+
+        assert assemble_chart_data() == (
+            test_class_name, test_chart_name, test_chart_filename, mock_score_avatar_dict, mock_chart_params)
 
 
 class TestGetCustomChartOptions(TestCase):

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -1,6 +1,3 @@
-from unittest import TestCase
-from unittest.mock import patch
-
 from dionysus_app.chart_generator import create_chart
 from dionysus_app.chart_generator.create_chart import (assemble_chart_data,
                                                        get_custom_chart_options,
@@ -169,12 +166,17 @@ class TestSetChartParams:
         assert set_chart_params() == test_params
 
 
-class TestGetCustomChartOptions(TestCase):
-    def setUp(self):
-        self.test_default_params = {'default param': 'my default param value'}
+class TestGetCustomChartOptions:
+    def test_get_custom_chart_options(self, monkeypatch):
+        test_default_params = {'default param': 'my default param value'}
 
-    @patch('dionysus_app.chart_generator.create_chart.take_custom_chart_options')
-    def test_get_custom_chart_options(self, mock_custom_chart_options):
-        assert get_custom_chart_options(self.test_default_params) == self.test_default_params
+        take_custom_chart_options_mock = {'called': False}
 
-        mock_custom_chart_options.assert_called_once()
+        def mocked_take_custom_chart_options():
+            take_custom_chart_options_mock['called'] = True
+
+        monkeypatch.setattr(create_chart, 'take_custom_chart_options', mocked_take_custom_chart_options)
+
+        assert get_custom_chart_options(test_default_params) == test_default_params
+
+        assert take_custom_chart_options_mock['called']

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -15,11 +15,11 @@ class TestTakeStudentScores:
         test_score_avatar_dict = {'test_student_scores': 'test student avatars'}
 
         test_chart_data_dict = {'class_name': test_class_name,
-                           'chart_name': test_chart_name,
-                           'chart_default_filename': test_chart_default_filename,
-                           'chart_params': test_chart_params,
-                           'score-avatar_dict': test_score_avatar_dict,
-                           }
+                                'chart_name': test_chart_name,
+                                'chart_default_filename': test_chart_default_filename,
+                                'chart_params': test_chart_params,
+                                'score-avatar_dict': test_score_avatar_dict,
+                                }
 
         test_chart_image_location = 'some image location'
 
@@ -60,7 +60,6 @@ class TestGetCustomChartOptions(TestCase):
 
     @patch('dionysus_app.chart_generator.create_chart.take_custom_chart_options')
     def test_get_custom_chart_options(self, mock_custom_chart_options):
-
         assert get_custom_chart_options(self.test_default_params) == self.test_default_params
 
         mock_custom_chart_options.assert_called_once()

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -80,18 +80,21 @@ class TestAssembleChartData:
             return test_class_name
 
         def mocked_load_class_from_disk(class_name):
-            assert class_name == test_class_name
+            if class_name != test_class_name:
+                raise ValueError
             return test_class
 
         def mocked_take_score_data(class_obj):
-            assert class_obj is test_class
+            if class_obj is not test_class:
+                raise ValueError
             return mock_score_avatar_dict
 
         def mocked_take_chart_name():
             return test_chart_name
 
         def mocked_clean_for_filename(chart_name):
-            assert chart_name == test_chart_name
+            if chart_name != test_chart_name:
+                raise ValueError
             return test_chart_name
 
         def mocked_set_chart_params():
@@ -127,14 +130,19 @@ class TestWriteChartDataToFile:
         assert test_file_folder.exists()
 
         def mocked_sanitise_avatar_path_objects(file_chart_data_dict):
-            assert file_chart_data_dict == test_chart_data_dict
+            if file_chart_data_dict != test_chart_data_dict:
+                raise ValueError('The dict of chart data did not contain expected items.')
             # file_chart_data_dict should be a deepcopy, not a reference to the original chart_data_dict.
-            assert file_chart_data_dict is not test_chart_data_dict
+            if file_chart_data_dict is test_chart_data_dict:
+                raise ValueError("A reference to the original chart data dict was passed. \n"
+                                 "An exact (deep)copy should be passed, because sanitise_avatar_path_objects \n"
+                                 "will mutate ('sanitise') the dict passed to it.\n")
 
             return file_chart_data_dict
 
         def mocked_convert_to_json(json_safe_dict):
-            assert json_safe_dict == test_chart_data_dict
+            if json_safe_dict != test_chart_data_dict:
+                raise ValueError
             return test_text_written_to_file
 
         monkeypatch.setattr(create_chart, 'CLASSLIST_DATA_PATH', tmp_path)

--- a/test_suite/test_chart_generator/test_create_chart.py
+++ b/test_suite/test_chart_generator/test_create_chart.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from unittest import TestCase
 from unittest.mock import patch
 

--- a/test_suite/test_class_functions.py
+++ b/test_suite/test_class_functions.py
@@ -480,7 +480,7 @@ class TestSelectStudent:
         assert select_student(test_class) == test_class_students[selected_student_students_index]
 
 
-class TestLoadClassData(TestCase):
+class TestLoadClassFromDisk(TestCase):
     mock_CLASSLIST_DATA_PATH = Path('.')
     mock_CLASSLIST_DATA_FILE_TYPE = '.class_data_file'
 
@@ -574,3 +574,7 @@ class TestEditClasslist(TestCase):
         mocked_open = mock_open()
         with patch('dionysus_app.class_functions.open', mocked_open):
             assert edit_classlist() is None
+
+
+class TestLoad_class_from_disk(TestCase):
+    pass

--- a/test_suite/test_class_functions.py
+++ b/test_suite/test_class_functions.py
@@ -473,18 +473,6 @@ class TestSelectStudent:
 
         assert select_student(test_class) == selected_student
 
-class TestCreateStudentListDict(TestCase):
-    def setUp(self):
-        self.test_class_json_dict = test_full_class_data_set['json_dict_rep']
-        self.test_class_name = self.test_class_json_dict['name']
-
-        self.test_class_object = Class.from_dict(self.test_class_json_dict)
-        self.enumerated_test_class_students_dict = test_full_class_data_set['enumerated_dict']
-
-    @patch('dionysus_app.class_functions.load_class_from_disk')
-    def test_create_student_list_dict_patching_load_class_data(self, mock_load_class_data):
-        mock_load_class_data.return_value = self.test_class_object
-        assert create_student_list_dict(self.test_class_name) == self.enumerated_test_class_students_dict
 
 
 class TestLoadClassData(TestCase):

--- a/test_suite/test_class_functions.py
+++ b/test_suite/test_class_functions.py
@@ -458,7 +458,7 @@ class TestSelectStudent:
                              [('one', 0),
                               ('two', 1),
                               ('three', 2),
-                             ])
+                              ])
     def test_select_student(self, monkeypatch, selected_student_name, selected_student_students_index):
         test_class_students = [Student(name='one'), Student(name='two'), Student(name='three')]
         test_class = Class(name='some_class', students=test_class_students)

--- a/test_suite/test_class_functions.py
+++ b/test_suite/test_class_functions.py
@@ -16,7 +16,6 @@ from dionysus_app.class_functions import (avatar_path_from_string,
                                           create_classlist,
                                           create_classlist_data,
                                           create_class_list_dict,
-                                          create_student_list_dict,
                                           edit_classlist,
                                           get_avatar_path,
                                           load_chart_data,
@@ -454,14 +453,10 @@ class TestCreateClassListDict(TestCase):
 
 class TestSelectStudent:
     def test_select_student(self, monkeypatch):
-        test_class_name = 'some_class'
+        test_class_students = [Student(name='one'), Student(name='two'), Student(name='three')]
+        test_class = Class(name='some_class', students=test_class_students)
         test_student_options = {1: 'one', 2: 'two', 3: 'three'}
         selected_student = 'some_student'
-
-        def mocked_create_student_list_dict(class_name):
-            if class_name != test_class_name:
-                raise ValueError  # Ensure called with correct arg.
-            return test_student_options
 
         def mocked_display_student_selection_menu(class_options):
             if class_options != test_student_options:
@@ -473,12 +468,10 @@ class TestSelectStudent:
                 raise ValueError  # Ensure called with correct arg.
             return selected_student
 
-        monkeypatch.setattr(class_functions, 'create_student_list_dict', mocked_create_student_list_dict)
         monkeypatch.setattr(class_functions, 'display_student_selection_menu', mocked_display_student_selection_menu)
         monkeypatch.setattr(class_functions, 'take_student_selection', mocked_take_student_selection)
 
-        assert select_student(test_class_name) == selected_student
-
+        assert select_student(test_class) == selected_student
 
 class TestCreateStudentListDict(TestCase):
     def setUp(self):

--- a/test_suite/test_class_functions.py
+++ b/test_suite/test_class_functions.py
@@ -8,6 +8,8 @@ from unittest.mock import patch, mock_open
 
 from unittest import mock, TestCase  # this is needed to use mock.call, since from mock import call causes an error.
 
+import pytest
+
 from dionysus_app import class_functions
 from dionysus_app.class_ import Class
 from dionysus_app.class_functions import (avatar_path_from_string,
@@ -452,11 +454,15 @@ class TestCreateClassListDict(TestCase):
 
 
 class TestSelectStudent:
-    def test_select_student(self, monkeypatch):
+    @pytest.mark.parametrize('selected_student_name, selected_student_students_index',
+                             [('one', 0),
+                              ('two', 1),
+                              ('three', 2),
+                             ])
+    def test_select_student(self, monkeypatch, selected_student_name, selected_student_students_index):
         test_class_students = [Student(name='one'), Student(name='two'), Student(name='three')]
         test_class = Class(name='some_class', students=test_class_students)
         test_student_options = {1: 'one', 2: 'two', 3: 'three'}
-        selected_student = 'some_student'
 
         def mocked_display_student_selection_menu(class_options):
             if class_options != test_student_options:
@@ -466,13 +472,12 @@ class TestSelectStudent:
         def mocked_take_student_selection(class_options):
             if class_options != test_student_options:
                 raise ValueError  # Ensure called with correct arg.
-            return selected_student
+            return selected_student_name
 
         monkeypatch.setattr(class_functions, 'display_student_selection_menu', mocked_display_student_selection_menu)
         monkeypatch.setattr(class_functions, 'take_student_selection', mocked_take_student_selection)
 
-        assert select_student(test_class) == selected_student
-
+        assert select_student(test_class) == test_class_students[selected_student_students_index]
 
 
 class TestLoadClassData(TestCase):

--- a/test_suite/test_file_functions.py
+++ b/test_suite/test_file_functions.py
@@ -10,7 +10,7 @@ from dionysus_app.file_functions import (convert_to_json,
                                          load_from_json_file,
                                          )
 from dionysus_app.file_functions import copy_file, move_file
-from test_suite.testing_class_data import testing_class_data_set as test_json_class_data
+from test_suite.testing_class_data import test_full_class_data_set as test_json_class_data
 
 
 class TestConvertToJson(TestCase):
@@ -32,7 +32,7 @@ class TestLoadFromJson(TestCase):
         assert load_from_json(self.json_data_to_convert) == self.converted_json_data
 
     def test_load_from_json_test_class_data(self):
-        assert load_from_json(self.test_json_class_data['json_data_string']) == self.test_json_class_data['loaded_dict']
+        assert load_from_json(self.test_json_class_data['json_str_rep']) == self.test_json_class_data['json_dict_rep']
 
 
 class TestLoadFromJsonFile(TestCase):

--- a/test_suite/testing_class_data.py
+++ b/test_suite/testing_class_data.py
@@ -133,8 +133,8 @@ test_full_class_data_set = {'json_str_rep': test_full_class_data_set_json_string
                             'enumerated_dict': test_full_class_data_set_enumerated_dict,
                             }
 
-"""Old style class data sets"""
-testing_class_data_set_json_string = '{\n    "Cali": [\n        "Cali_avatar.png"\n    ],\n    "Monty": ' \
+"""Depreciated old style class data sets"""
+old_style_testing_class_data_set_json_string = '{\n    "Cali": [\n        "Cali_avatar.png"\n    ],\n    "Monty": ' \
                                      '[\n        null\n    ],\n    "Abby": [\n        null\n    ],' \
                                      '\n    "Zach": [\n        "Zach_avatar.png"\n    ],\n    "Janell": ' \
                                      '[\n        null\n    ],\n    "Matthew": [\n        null\n    ],' \
@@ -145,22 +145,22 @@ testing_class_data_set_json_string = '{\n    "Cali": [\n        "Cali_avatar.png
                                      '\n    "Danielle": [\n        "Danielle.png"\n    ],\n    "Kayla": ' \
                                      '[\n        null\n    ],\n    "Jaleigh": [\n        null\n    ]\n}'
 
-testing_class_data_set_loaded_dict = {'Cali': ['Cali_avatar.png'], 'Monty': [None], 'Abby': [None],
+old_style_testing_class_data_set_loaded_dict = {'Cali': ['Cali_avatar.png'], 'Monty': [None], 'Abby': [None],
                                       'Zach': ['Zach_avatar.png'], 'Janell': [None], 'Matthew': [None],
                                       'Olivia': [None], 'Regina': [None], 'Ashley': ['Ashley_avatar.png'],
                                       'Alex': [None], 'Melissa': [None], 'Edgar': [None],
                                       'Danielle': ['Danielle.png'], 'Kayla': [None], 'Jaleigh': [None]
                                       }
 
-testing_class_data_set_enumerated_dict = {1: 'Cali', 2: 'Monty', 3: 'Abby', 4: 'Zach', 5: 'Janell', 6: 'Matthew',
+old_style_testing_class_data_set_enumerated_dict = {1: 'Cali', 2: 'Monty', 3: 'Abby', 4: 'Zach', 5: 'Janell', 6: 'Matthew',
                                           7: 'Olivia', 8: 'Regina', 9: 'Ashley', 10: 'Alex', 11: 'Melissa', 12: 'Edgar',
                                           13: 'Danielle', 14: 'Kayla', 15: 'Jaleigh',
                                           }
 
-testing_class_data_set = {
-    'json_data_string': testing_class_data_set_json_string,
-    'loaded_dict': testing_class_data_set_loaded_dict,
-    'enumerated_dict': testing_class_data_set_enumerated_dict,
+old_style_testing_class_data_set = {
+    'json_data_string': old_style_testing_class_data_set_json_string,
+    'loaded_dict': old_style_testing_class_data_set_loaded_dict,
+    'enumerated_dict': old_style_testing_class_data_set_enumerated_dict,
 }
 
 """


### PR DESCRIPTION
Change select_student to take Class object.
Have select_student return a Student object.
Remove `create_student_list_dict` 

Assorted PEP8, test coverage #175, docstring, and type hinting improvements #120, including multiple specifications of Path rather than string or Union[Path, str]` in move toward #123. 