### PR TITLE
Late pre-release CHANGELOG editing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0-alpha] - 2020-01-23
 ### Added
-- Updated dependencies.
-- Improved test coverage.
-- Type hinting across application. 
+- Improved test coverage, type hinting across application. 
 - mypy check to added to CI.
 - Python 3.8 compatibility and CI integration.
 - Runtime guards raising a meaningful `ValueError` on uninitialised `definitions.REGISTRY`, `definitions.DEFAULT_CHART_SAVE_FOLDER`. NB this should only happen when tests are run without config.
-- Option to go directly from creating a class to chart with that class. 
+- Option to go directly from creating a class to creating a chart with the newly created class.
 ### Changed
+- Updated dependencies - fixes some unlikely security issues.
 - `select_student` now uses Class object, returns Student object.
 - `file_functions` tests now all use new-style class data.
 ### Depreciated


### PR DESCRIPTION
Move dependency bump to `Changed`, add note that some of these fix potential (highly unlikely) security issues.
Clarify wording.