### PR TITLE
Simplify pytest command and use branch coverage.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,5 +19,4 @@ install:
     - uv sync --all-groups
 
 test_script:
-    - uv run pytest --cov=./ --mypy -vv
-    - uv run coverage xml -i
+    - uv run pytest --cov=./ --mypy -vv --cov-report html --cov-report xml --cov-report=lcov --cov-branch

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,9 +47,7 @@ jobs:
     - name: Test with pytest --cov=./ --mypy -vv
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        uv run pytest --cov=./ --mypy -vv
-        uv run coverage xml -i
+      run: uv run pytest --cov=./ --mypy -vv --cov-report html --cov-report xml --cov-report=lcov --cov-branch
 
 
     - name: Codacy Coverage Reporter

--- a/.gitignore
+++ b/.gitignore
@@ -46,14 +46,18 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
 *.cover
+*.py,cover
 .hypothesis/
 .pytest_cache/
+cover/
+*.lcov
 
 # Translations
 *.mo


### PR DESCRIPTION
## Changes

- Simplified pytest commands for lcov and xml coverage; `uv run coverage` is no longer necessary.
- Added HTML coverage (and relevant gitignore entries); you can now view line-by-line coverage details conveniently in your web browser via the generated `htmlcov/index.html`.
- Enable pytest's branch coverage measurement feature for more thorough testing.

I've also considered using [pytest-xdist](https://pypi.org/project/pytest-xdist) for running tests in parallel but the test warmup time causes the overall test runtime to be longer, and there are race conditions when multiple test runners attempt to access the same temp directory.